### PR TITLE
Added a version number to the source

### DIFF
--- a/Helios/Helios.cpp
+++ b/Helios/Helios.cpp
@@ -38,11 +38,6 @@ bool Helios::keepgoing;
 bool Helios::sleeping;
 #endif
 
-#define HELIOS_VERSION 1.1.125
-#define HELIOS_VERSION_STR STR(HELIOS_VERSION)
-#define _STR(x) #x
-#define STR(x) _STR(x)
-
 volatile char helios_version[] = HELIOS_VERSION_STR;
 
 bool Helios::init()

--- a/Helios/Helios.cpp
+++ b/Helios/Helios.cpp
@@ -38,6 +38,13 @@ bool Helios::keepgoing;
 bool Helios::sleeping;
 #endif
 
+#define HELIOS_VERSION 1.1.125
+#define HELIOS_VERSION_STR STR(HELIOS_VERSION)
+#define _STR(x) #x
+#define STR(x) _STR(x)
+
+volatile char helios_version[] = HELIOS_VERSION_STR;
+
 bool Helios::init()
 {
   // first initialize all the components of helios

--- a/Helios/HeliosConfig.h
+++ b/Helios/HeliosConfig.h
@@ -1,6 +1,23 @@
 #ifndef HELIOS_CONFIG_H
 #define HELIOS_CONFIG_H
 
+// Helper macros to expand out the version into a string
+#define _STR(x) #x
+#define STR(x) _STR(x)
+
+// Helios Version Number
+//
+// It is expected that HELIOS_VERSION will be provided on the command line to the
+// compiler as a -DHELIOS_VERSION=a.b.c but if it's not it will default here
+#ifndef HELIOS_VERSION
+#define HELIOS_VERSION 0.0.1
+#endif
+
+// Helios Version String
+//
+// This is the string literal equivalent of HELIOS_VERSION above
+#define HELIOS_VERSION_STR    STR(HELIOS_VERSION)
+
 // Short Click Threshold
 //
 // The length of time in milliseconds for a click to


### PR DESCRIPTION
This would allow the binary to contain a version string so you can check a pulled firmware file for it's version easily with the 'strings' command line utility. 

Unfortunately this is only half of the work, the version needs to be passed in through the makefile still -- shouldn't be hard I just never got around to it