### PR TITLE
Kurt/aeos/brightness-control

### DIFF
--- a/Helios/Helios.cpp
+++ b/Helios/Helios.cpp
@@ -619,7 +619,7 @@ void Helios::handle_state_color_brightness_selection()
   if (Button::onShortClick()) {
     menu_selection = (menu_selection + 1) % 4;
   }
-  static const uint8_t brightness_values[4] = {255, 128, 64, 32};
+  static const uint8_t brightness_values[4] = {HSV_VAL_HIGH, HSV_VAL_MEDIUM, HSV_VAL_LOW, HSV_VAL_LOWEST};
   selected_brightness = brightness_values[menu_selection];
   HSVColor hsv = rgb_to_hsv_generic(selected_color);
   hsv.val = selected_brightness;

--- a/Helios/Helios.h
+++ b/Helios/Helios.h
@@ -62,6 +62,7 @@ private:
   static void handle_state_color_selection();
   static void handle_state_color_group_selection();
   static void handle_state_color_variant_selection();
+  static void handle_state_color_brightness_selection();
   static void handle_state_pat_select();
   static void handle_state_toggle_flag(Flags flag);
   static void handle_state_set_defaults();
@@ -72,6 +73,7 @@ private:
     STATE_MODES,
     STATE_COLOR_GROUP_SELECTION,
     STATE_COLOR_VARIANT_SELECTION,
+    STATE_COLOR_SELECT_BRIGHTNESS,
     STATE_PATTERN_SELECT,
     STATE_TOGGLE_CONJURE,
     STATE_TOGGLE_LOCK,
@@ -89,6 +91,8 @@ private:
   static uint8_t cur_mode;
   // the group that was selected in color select
   static uint8_t selected_base_group;
+  static RGBColor selected_color;
+  static uint8_t selected_brightness;
   static uint8_t num_colors_selected;  // Track number of colors selected in current session
   static Pattern pat;
   static bool keepgoing;

--- a/Helios/HeliosConfig.h
+++ b/Helios/HeliosConfig.h
@@ -109,6 +109,12 @@
 // color selection menu and provide a slightly different range of colors
 #define ALTERNATIVE_HSV_RGB 0
 
+// Pre-defined brightness values
+#define HSV_VAL_HIGH      255
+#define HSV_VAL_MEDIUM    120
+#define HSV_VAL_LOW       60
+#define HSV_VAL_LOWEST    10
+
 // ============================================================================
 //  Storage Constants
 //


### PR DESCRIPTION
- Updated the brightness selection logic to utilize defined constants for better readability and maintainability.
- Introduced new constants for brightness levels in HeliosConfig.h: HSV_VAL_HIGH, HSV_VAL_MEDIUM, HSV_VAL_LOW, and HSV_VAL_LOWEST.
- Ensured that the brightness selection functionality remains intact while improving code clarity.